### PR TITLE
Replace optimist with successor yargs

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
   },
   "dependencies": {
     "boom": "~2.10.0",
-    "optimist": "~0.6.1"
+    "yargs": "~3.29.0"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,15 +2,25 @@
 'use strict';
 
 import gitio from './index';
-import optimist from 'optimist';
+import yargs from 'yargs';
 
 
 let process = () => {
-  let program = optimist
+  let program = yargs
     .usage('Usage: $0 user/repo [-u github url] [-c code]')
-    .alias('u', 'url')
-    .alias('c', 'code')
+    .option('u', {
+     alias: 'url',
+     describe: "Github url",
+     demand: true
+    })
+    .option('c', {
+     alias: 'code',
+     describe: "Code",
+     demand: false
+    })
     .wrap(80)
+    .help('h')
+    .alias('h', 'help')
     .argv;
 
   let url = '';
@@ -28,6 +38,7 @@ let process = () => {
     }
   }
 
+  //TODO: this will never be reached because yargs is demanding url option
   if (!url) {
     return console.error(`${program.$0}: No URL passed`);
   }


### PR DESCRIPTION
This will replace optimist with its successor yargs and also demand url
option to be set.

Also added a help option