### PR TITLE
re: updated regex

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,7 +4,7 @@
 const gitio = require('./gitio');
 const yargs = require('yargs');
 
-const URL_REGEX = /^https?:\/\/(([A-Za-z0-9\-]+\.)?(github\.(com|io))|raw\.githubusercontent\.com)(\/[A-Za-z0-9\?%$#&=\-_\.]{0,})+$/;
+const URL_REGEX = /^https?:\/\/(([A-Za-z0-9\-]+\.)?(github\.(com|io))|raw\.githubusercontent\.com)(\/[A-Za-z0-9\?%#&=\-_\.]{0,})+$/;
 
 const process = () => {
   const program = yargs

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,6 +4,8 @@
 const gitio = require('./gitio');
 const yargs = require('yargs');
 
+const URL_REGEX = /^https?:\/\/(([A-Za-z0-9\-]+\.)?(github\.(com|io))|raw\.githubusercontent\.com)(\/[A-Za-z0-9\?%$#&=\-_\.]{0,})+$/;
+
 const process = () => {
   const program = yargs
     .usage('Usage: $0 user/repo [-u github url] [-c code]')
@@ -22,14 +24,15 @@ const process = () => {
     .alias('h', 'help')
     .argv;
 
+  console.log(program);
   let url = '';
-  const code = program.c ? program.c : false;
+  const code = program.c; // undefined OR actual --code
 
   if (program.u) {
     url = program.u;
   } else {
     if (program._[0]) {
-      if (/^(https:|http:)\/\/(github\.com)\/[A-Za-z0-9\?&=\-_\/]+$/.test(program._[0])) {
+      if (URL_REGEX.test(program._[0])) {
         url = program._[0];
       } else {
         url = 'https://github.com/' + program._[0];

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -24,7 +24,6 @@ const process = () => {
     .alias('h', 'help')
     .argv;
 
-  console.log(program);
   let url = '';
   const code = program.c; // undefined OR actual --code
 

--- a/lib/gitio.js
+++ b/lib/gitio.js
@@ -3,7 +3,7 @@
 const request = require('https').request;
 const Boom = require('boom');
 
-const URL_REGEX = /^https:\/\/(github\.com|raw\.githubusercontent\.com|[A-Za-z0-9\-]+\.github\.io)\/[A-Za-z0-9\?#&=\-_\.\/]+$/;
+const URL_REGEX = /^https?:\/\/(([A-Za-z0-9\-]+\.)?(github\.(com|io))|raw\.githubusercontent\.com)(\/[A-Za-z0-9\?%$#&=\-_\.]{0,})+$/;
 const REQUEST_CONFIG = {
   host: 'git.io',
   method: 'POST',
@@ -20,7 +20,7 @@ const gitIo = (address, code) => {
       return reject(Boom.badData('The url ' + address + ' is not a valid address for git.io'));
     }
 
-    const body = 'url=' + address + (code ? '&code=' + code : '');
+    const body = `url=${address}&code=${code||''}`; // if code is undefined => ''
     const req = request(
       Object.assign(
         {},

--- a/lib/gitio.js
+++ b/lib/gitio.js
@@ -3,7 +3,7 @@
 const request = require('https').request;
 const Boom = require('boom');
 
-const URL_REGEX = /^https?:\/\/(([A-Za-z0-9\-]+\.)?(github\.(com|io))|raw\.githubusercontent\.com)(\/[A-Za-z0-9\?%$#&=\-_\.]{0,})+$/;
+const URL_REGEX = /^https?:\/\/(([A-Za-z0-9\-]+\.)?(github\.(com|io))|raw\.githubusercontent\.com)(\/[A-Za-z0-9\?%#&=\-_\.]{0,})+$/;
 const REQUEST_CONFIG = {
   host: 'git.io',
   method: 'POST',


### PR DESCRIPTION
- subdomains now include (pages|help|status|education|...).github.com
- paths now include URI-encoded unicode characters
- paths are now optional, due to `http://SUBDOMAIN.github.io`

``` regex
/^https?:\/\/
  ( 
    ([A-Za-z0-9\-]+\.)?
      (github\.(com|io))
    |raw\.githubusercontent\.com
  )
  (\/[A-Za-z0-9\?%#&=\-_\.]{0,})+
$/
```
tested for `https://github.com/Rabrennie/anything.js/blob/master/%F0%9F%92%A9.json` (`💩.json`):

``` sh
chmod +x ./lib/cli.js
./lib/cli.js -u https://github.com/Rabrennie/anything.js/blob/master/%F0%9F%92%A9.json -c poop.json
{ _: [],
  h: false,
  help: false,
  u: 'https://github.com/Rabrennie/anything.js/blob/master/%F0%9F%92%A9.json',
  url: 'https://github.com/Rabrennie/anything.js/blob/master/%F0%9F%92%A9.json',
  c: 'poop.json',
  code: 'poop.json',
  '$0': 'cli.js' }
https://git.io/vSJXr
```

----
`--code` still doesn't work, will dig later